### PR TITLE
Handle Redis response errors instead of silencing them

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,12 @@ To use it, just use the ``asgi_redis.RedisLocalChannelLayer`` class in your
 configuration instead of ``RedisChannelLayer`` and make sure you have the
 ``asgi_ipc`` package installed; no other change is needed.
 
+Supported versions
+------------------
+
+Python 2.7 and Python 3.3 - 3.5 are supported. Redis >= 2.6 and Django >= 1.7
+are required.
+
 
 Maintenance and Security
 ------------------------

--- a/asgi_redis/core.py
+++ b/asgi_redis/core.py
@@ -21,6 +21,10 @@ from asgiref.base_layer import BaseChannelLayer
 from .twisted_utils import defer
 
 
+class UnsupportedRedis(Exception):
+    pass
+
+
 class RedisChannelLayer(BaseChannelLayer):
     """
     ORM-backed channel environment. For development use only; it will span
@@ -108,6 +112,13 @@ class RedisChannelLayer(BaseChannelLayer):
             # The Lua script handles capacity checking and sends the "full" error back
             if e.args[0] == "full":
                 raise self.ChannelFull
+            elif "unknown command" in e.args[0]:
+                raise UnsupportedRedis(
+                    "Redis returned an error (%s). Please ensure you're running a "
+                    " version of redis that is supported by asgi_redis." % e.args[0])
+            else:
+                # Let any other exception bubble up
+                raise
 
     def receive_many(self, channels, block=False):
         # List name get


### PR DESCRIPTION
The exception handling for send() silenced all Redis errors apart from the
"full" message. This commit updates the exception logic to also
specifically handle the "unknown command" error which might point at an
unsupported version of Redis. It also now lets any other exception bubble
up instead of being silently dropped.

Reported by @wynbennett in https://github.com/django/asgi_redis/issues/14.

I also added a wild guess as to what versions asgi_redis might support. I'm happy to also add Travis support for the whole grid of supported Django, Python and Travis versions if @andrewgodwin thinks it's a good idea.